### PR TITLE
fix: selector "#feature" won't point to an element in "www.plasmo.com"

### DIFF
--- a/with-content-scripts-ui/contents/plasmo-inline.tsx
+++ b/with-content-scripts-ui/contents/plasmo-inline.tsx
@@ -5,7 +5,7 @@ export const config: PlasmoContentScript = {
 }
 
 export const getInlineAnchor: PlasmoGetInlineAnchor = () =>
-  document.querySelector("#supercharge > h2 > span")
+  document.querySelector("#supercharge > h3 > span")
 
 // Use this to optimize unmount lookups
 export const getShadowHostId = () => "plasmo-inline-example-unique-id"

--- a/with-content-scripts-ui/contents/plasmo-root-container.tsx
+++ b/with-content-scripts-ui/contents/plasmo-root-container.tsx
@@ -8,7 +8,7 @@ export const config: PlasmoContentScript = {
 export const getRootContainer = () =>
   new Promise((resolve) => {
     const checkInterval = setInterval(() => {
-      const rootContainer = document.getElementById("feature")
+      const rootContainer = document.getElementById("itero")
       if (rootContainer) {
         clearInterval(checkInterval)
         resolve(rootContainer)
@@ -20,9 +20,10 @@ const PlasmoOverlay = () => {
   return (
     <span
       style={{
+        background: "yellow",
         padding: 12
       }}>
-      <h1>HELLO WORLD ROOT CONTAINER</h1>
+      HELLO WORLD ROOT CONTAINER
     </span>
   )
 }


### PR DESCRIPTION
I discussed with @louisgv about this tiny issue on Discord. Here is the link:

https://discord.com/channels/946290204443025438/1044559116581994527

With changes in this PR, now the website will be affected like this:

<img width="1587" alt="image" src="https://user-images.githubusercontent.com/32434520/203458637-de58c2e7-e7c6-4d4b-b0a0-bcad2a2da151.png">

Louis is a really nice guy and he helps me with many questions, thanks louis!

---

BTW, since the example repo is as a submodule of the plasmo repo. After this PR is merged, should I do something else to make the submodule be synced?
