### PR TITLE
feat: Redux hooks with defined types using workaround

### DIFF
--- a/with-redux/counter.tsx
+++ b/with-redux/counter.tsx
@@ -1,10 +1,11 @@
-import { useDispatch, useSelector } from "react-redux"
-
-import { CounterState, decrement, increment } from "~counter-slice"
+import { decrement, increment } from "~counter-slice"
+import { useAppDispatch, useAppSelector } from "~store"
 
 export const CounterView = () => {
-  const dispatch = useDispatch()
-  const value = useSelector((state: CounterState) => state.count)
+  const dispatch = useAppDispatch()
+
+  // Make sure to use "useAppSelector" instead of "useSelector" to automatically get the correct types
+  const value = useAppSelector((state) => state.counter.count)
 
   return (
     <div>

--- a/with-redux/store.ts
+++ b/with-redux/store.ts
@@ -1,3 +1,5 @@
+import { useDispatch, useSelector, TypedUseSelectorHook } from "react-redux";
+
 import {
   FLUSH,
   PAUSE,
@@ -10,44 +12,63 @@ import {
   persistStore
 } from "@plasmohq/redux-persist"
 import { Storage } from "@plasmohq/storage"
-import { configureStore } from "@reduxjs/toolkit"
+import { configureStore, combineReducers } from "@reduxjs/toolkit"
 import { localStorage } from "redux-persist-webextension-storage"
 
 import counterSlice from "~counter-slice"
 
-const rootReducer = counterSlice
+// Here you can add all your reducers
+const combinedReducers = combineReducers({
+    counter: counterSlice
+});
 
 const persistConfig = {
-  key: "root",
-  version: 1,
-  storage: localStorage
+    key: "root",
+    version: 1,
+    storage: localStorage
 }
 
-const persistedReducer = persistReducer(persistConfig, rootReducer)
+// TODO: Fix persistReducer so it doesn't break the types
+const persistedReducer = persistReducer(persistConfig, combinedReducers)
 
-export const store = configureStore({
-  reducer: persistedReducer,
-  middleware: (getDefaultMiddleware) =>
-    getDefaultMiddleware({
-      serializableCheck: {
-        ignoredActions: [
-          FLUSH,
-          REHYDRATE,
-          PAUSE,
-          PERSIST,
-          PURGE,
-          REGISTER,
-          RESYNC
-        ]
-      }
-    })
+// Until persistReducer is fixed, we need to use this mock store to get the types
+const mockStore = configureStore({
+    reducer: combinedReducers
 })
+
+// @ts-ignore
+export const store = configureStore({
+    reducer: persistedReducer,
+    middleware: (getDefaultMiddleware) =>
+        getDefaultMiddleware({
+            serializableCheck: {
+                ignoredActions: [
+                    FLUSH,
+                    REHYDRATE,
+                    PAUSE,
+                    PERSIST,
+                    PURGE,
+                    REGISTER,
+                    RESYNC
+                ]
+            }
+        })
+}) as typeof mockStore;
+
 export const persistor = persistStore(store)
 
 // This is what makes Redux sync properly with multiple pages
 // Open your extension's options page and popup to see it in action
 new Storage().watch({
-  [`persist:${persistConfig.key}`]: () => {
-    persistor.resync()
-  }
+    [`persist:${persistConfig.key}`]: () => {
+        persistor.resync()
+    }
 })
+
+// Get the types from the mock store
+export type RootState = ReturnType<typeof mockStore.getState>;
+export type AppDispatch = typeof mockStore.dispatch;
+
+// Export the hooks with the types from the mock store
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;


### PR DESCRIPTION
In order to get hooks with defined types, a mock store is made.
The reason the mock store is needed is because the "persistReducer" function removes the types.
The mock user is then used to get the types for the hooks.

The hooks with defined types is recommended by redux toolkit and is the standard when using redux with typescript
[Redux toolkit docs](https://react-redux.js.org/using-react-redux/usage-with-typescript#define-typed-hooks)