### PR TITLE
Example README.md link returns 404, trying to correct that.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pnpm create plasmo --with-<example-name>
 npm create plasmo -- --with-<example-name>
 ```
 
-For more detail, please read this documentation: https://docs.plasmo.com/framework/workflows#with-an-example-template
+For more detail, please read this documentation: https://docs.plasmo.com/framework/workflows/new#with-an-example-template
 
 And see the discussion here for details on how to work with this example repository: https://discord.com/channels/946290204443025438/1044558522316234752
 


### PR DESCRIPTION
The original link gave a 404 message, corrected the link to what I believe is the intended link.

If it's not correct, this should be corrected by someone who knows the right one.