### PR TITLE
Add main world to bgsw flow example to with-messaging

### DIFF
--- a/with-messaging/background/messages/open-extension.ts
+++ b/with-messaging/background/messages/open-extension.ts
@@ -1,0 +1,22 @@
+import type { PlasmoMessaging } from "@plasmohq/messaging"
+
+const handler: PlasmoMessaging.MessageHandler = async (req, res) => {
+  chrome.windows.create(
+    {
+      url: chrome.runtime.getURL("popup.html"),
+      type: "popup",
+      width: 400,
+      height: 600
+    },
+    (window) => {
+      console.log(`Popup window created with ID ${window.id}`)
+    }
+  )
+  const message = "Hello from the background script!"
+
+  res.send({
+    message
+  })
+}
+
+export default handler

--- a/with-messaging/contents/handle-main-world.tsx
+++ b/with-messaging/contents/handle-main-world.tsx
@@ -1,0 +1,18 @@
+import type { PlasmoCSConfig } from "plasmo"
+
+import { sendToBackground } from "@plasmohq/messaging"
+import { relay } from "@plasmohq/messaging/relay"
+
+export const config: PlasmoCSConfig = {
+  matches: ["<all_urls>"]
+}
+
+relay(
+  {
+    name: "open-extension" as const
+  },
+  async (req) => {
+    const openResult = await sendToBackground(req)
+    return openResult
+  }
+)

--- a/with-messaging/contents/main-world.tsx
+++ b/with-messaging/contents/main-world.tsx
@@ -1,0 +1,19 @@
+import type { PlasmoCSConfig } from "plasmo"
+
+import { sendToBackgroundViaRelay } from "@plasmohq/messaging"
+
+export const config: PlasmoCSConfig = {
+  matches: ["<all_urls>"],
+  run_at: "document_start",
+  world: "MAIN"
+}
+
+window.relay = {
+  description: "Message from content script in main world",
+  tryRelay: async () => {
+    let result = await sendToBackgroundViaRelay({
+      name: "open-extension"
+    })
+    return result
+  }
+}


### PR DESCRIPTION
Added example of the secondary content script to handle main world content script relays. I was unable to see the injected `window.relay` on `http://localhost:1947/` so I left matching params as `<all_urls>` for the purpose of the example.