### PR TITLE
feat: improve error message when using firebase

### DIFF
--- a/with-firebase-auth/firebase/hook.ts
+++ b/with-firebase-auth/firebase/hook.ts
@@ -30,7 +30,7 @@ export const useFirebase = () => {
     setIsLoading(true)
     chrome.identity.getAuthToken({ interactive: true }, async function (token) {
       if (chrome.runtime.lastError || !token) {
-        console.error(chrome.runtime.lastError)
+        console.error(chrome.runtime.lastError.message)
         setIsLoading(false)
         return
       }


### PR DESCRIPTION
The current error log only returns an object, I have changed in to `lastError.message` to display the error message right away