### PR TITLE
fix: with-redux check for changed storage values

### DIFF
--- a/with-redux/store.ts
+++ b/with-redux/store.ts
@@ -61,8 +61,22 @@ export const persistor = persistStore(store)
 // This is what makes Redux sync properly with multiple pages
 // Open your extension's options page and popup to see it in action
 new Storage().watch({
-  [`persist:${persistConfig.key}`]: () => {
-    persistor.resync()
+  [`persist:${persistConfig.key}`]: (change) => {
+    const { oldValue, newValue } = change
+    const updatedKeys = []
+    for (const key in oldValue) {
+      if (oldValue[key] !== newValue?.[key]) {
+        updatedKeys.push(key)
+      }
+    }
+    for (const key in newValue) {
+      if (oldValue?.[key] !== newValue[key]) {
+        updatedKeys.push(key)
+      }
+    }
+    if (updatedKeys.length > 0) {
+      persistor.resync()
+    }
   }
 })
 

--- a/with-redux/store.ts
+++ b/with-redux/store.ts
@@ -1,5 +1,6 @@
 import { combineReducers, configureStore } from "@reduxjs/toolkit"
-import { TypedUseSelectorHook, useDispatch, useSelector } from "react-redux"
+import { useDispatch, useSelector } from "react-redux"
+import type { TypedUseSelectorHook } from "react-redux"
 import { syncStorage } from "redux-persist-webextension-storage"
 
 import {


### PR DESCRIPTION
As referenced on [this discussion](https://github.com/PlasmoHQ/plasmo/discussions/768).

Adds a commit which will check for values having changed on callback function given to `Storage.watch`. 

Performance of different approaches can be [seen here](https://jsperf.app/lezoki). Double for/in should have the best performance given the shape of the changes object given to the callback function (and is significantly faster than the unnecessary `JSON.stringify`). 

Opted not to use a Firefox-only gating as the [abandoned original webextensions spec](https://github.com/browserext/browserext/) and the new [community spec](https://github.com/w3c/webextensions) don't specify what the behavior should be so there's a good chance it'll change in the future in 1 or more browsers.  

Also included is a minor change to address a TS compiler error regarding imports. 