### PR TITLE
Google Analytics Measurement Protocol

### DIFF
--- a/with-google-analytics/background.ts
+++ b/with-google-analytics/background.ts
@@ -1,0 +1,32 @@
+import { Storage } from '@plasmohq/storage';
+import { AnalyticsEvent } from './utils';
+
+/**
+ * On install, generate a random client ID and store it in sync storage.
+ * This is used to identify unique users.
+ */
+chrome.runtime.onInstalled.addListener(async (details) => {
+	if(details.reason == "install"){
+			// Generate a random client ID.
+			const clientId = self.crypto.randomUUID();
+
+			// Storing in sync so that the client ID is synced across a user's devices.
+			const storage = new Storage({
+				area: 'sync',
+			});
+
+			await storage.set('clientId', clientId);
+
+			const platform = await chrome.runtime.getPlatformInfo();
+
+			// Send a new_install event to Google Analytics.
+			await AnalyticsEvent([
+				{
+					name: 'new_install',
+					params: {
+						operating_system: platform.os,
+					}
+				}
+			]);
+	}
+});

--- a/with-google-analytics/example.env.local
+++ b/with-google-analytics/example.env.local
@@ -1,1 +1,6 @@
+# Looks something like G-S41BHQWBA1
 PLASMO_PUBLIC_GTAG_ID=
+
+# Looks something like WbAPlQnvBa-SPDXsj3_dvL
+# https://developer.chrome.com/docs/extensions/mv3/tut_analytics/ google seem to say this is fine to be public?
+PLASMO_PUBLIC_SECRET_API_KEY= 

--- a/with-google-analytics/package.json
+++ b/with-google-analytics/package.json
@@ -5,7 +5,8 @@
   "description": "A basic Plasmo extension.",
   "author": "Plasmo Corp. <foss@plasmo.com>",
   "contributors": [
-    "louisgv"
+    "louisgv",
+    "acorn221"
   ],
   "scripts": {
     "dev": "plasmo dev",
@@ -13,6 +14,7 @@
     "package": "plasmo package"
   },
   "dependencies": {
+    "@plasmohq/storage": "workspace:1.8.0",
     "plasmo": "workspace:*",
     "react": "18.2.0",
     "react-dom": "18.2.0"
@@ -27,8 +29,11 @@
     "typescript": "5.2.2"
   },
   "manifest": {
+    "permissions": [
+      "storage"
+    ],
     "host_permissions": [
-      "https://ssl.google-analytics.com",
+      "https://www.google-analytics.com/*",
       "https://*/*"
     ]
   }

--- a/with-google-analytics/popup.tsx
+++ b/with-google-analytics/popup.tsx
@@ -1,37 +1,55 @@
-import "https://www.googletagmanager.com/gtag/js?id=$PLASMO_PUBLIC_GTAG_ID"
-
 import { useEffect, useState } from "react"
+import { AnalyticsEvent } from "~utils";
 
 function IndexPopup() {
   const [data, setData] = useState("")
 
   useEffect(() => {
-    window.dataLayer = window.dataLayer || []
-    window.gtag = function gtag() {
-      window.dataLayer.push(arguments) // eslint-disable-line
-    }
-    window.gtag("js", new Date())
-    window.gtag("config", process.env.PLASMO_PUBLIC_GTAG_ID, {
-      page_path: "/popup",
-      debug_mode: true
-    })
-
-    window.gtag("event", "login", {
-      method: "TEST"
-    })
-  }, [])
+    AnalyticsEvent([
+      {
+        name: 'page_view',
+        params: {
+          page_path: '/popup',
+          debug_mode: true
+        }
+      }
+    ]);
+    setTimeout(() => {
+      AnalyticsEvent([
+        {
+          name: 'page_view',
+          params: {
+            page_path: '/popup',
+            debug_mode: true,
+            duration: 5,
+          }
+        }
+      ]);
+    }, 5000)
+  }, []);
 
   return (
     <div
       style={{
         display: "flex",
         flexDirection: "column",
-        padding: 16
+        padding: 16,
+        minWidth: "250px",
       }}>
       <h1>
         Welcome to your <a href="https://www.plasmo.com">Plasmo</a> Extension!
       </h1>
       <input onChange={(e) => setData(e.target.value)} value={data} />
+      <button onClick={() => AnalyticsEvent([
+        {
+          name: 'button_click',
+          params: {
+            button_name: 'click_me',
+            debug_mode: true,
+            data: data,
+          }
+        }
+      ])}>Click Me</button>
     </div>
   )
 }

--- a/with-google-analytics/utils.ts
+++ b/with-google-analytics/utils.ts
@@ -1,0 +1,52 @@
+import { Storage } from '@plasmohq/storage';
+
+if(!process.env.PLASMO_PUBLIC_GTAG_ID) {
+	throw new Error('PLASMO_PUBLIC_GTAG_ID environment variable not set.');
+}
+
+if(!process.env.PLASMO_PUBLIC_SECRET_API_KEY) {
+	throw new Error('PLASMO_PUBLIC_SECRET_API_KEY environment variable not set.');
+}
+
+const GA_ENDPOINT = 'https://www.google-analytics.com/mp/collect';
+const gtagId = process.env.PLASMO_PUBLIC_GTAG_ID;
+const secretApiKey = process.env.PLASMO_PUBLIC_SECRET_API_KEY;
+
+// https://developers.google.com/analytics/devguides/collection/protocol/ga4/reference/events
+type CollectEventPayload = {
+	name: string,
+	params?: any,
+};
+
+/**
+ * This function sends events to Google Analytics using the Measurement Protocol.
+ * https://developers.google.com/analytics/devguides/collection/protocol/ga4/sending-events
+ * 
+ * @param events The events to send to Google Analytics.
+ */
+export const AnalyticsEvent = async (events: CollectEventPayload[]) => {
+	const storage = new Storage({
+		area: 'sync',
+	});
+
+	let clientId = await storage.get('clientId');
+
+	// Just incase the client ID was not set on install.
+	if(!clientId) {
+		clientId = self.crypto.randomUUID();
+		await storage.set('clientId', clientId);
+	}
+
+	const fetched = await fetch(
+		`${GA_ENDPOINT}?measurement_id=${gtagId}&api_secret=${secretApiKey}`,
+		{
+			method: 'POST',
+			body: JSON.stringify({
+				client_id: clientId,
+				events,
+			}),
+		}
+	);
+
+	return fetched;
+}


### PR DESCRIPTION
Hi, I've been waiting on my extension to get approved and I think the GA remote code declaration is what's slowing it down.
Google now recommends using the measurement protocol, instead of the old solution with remote code.

I'm not 100% sure about the measurement protocol as it doesn't seem as comprehensive as, for example, it's missing geolocation information.

I think this example would be useful to have at least, maybe it could be it's own example, instead of replacing the example using the legacy google-analytics?

https://developer.chrome.com/docs/extensions/mv3/tut_analytics/
https://developers.google.com/analytics/devguides/collection/protocol/ga4/