### PR TITLE
fix: popup style

### DIFF
--- a/with-popup/popup.tsx
+++ b/with-popup/popup.tsx
@@ -6,8 +6,6 @@ function IndexPopup() {
   return (
     <div
       style={{
-        display: "flex",
-        flexDirection: "column",
         padding: 16
       }}>
       <h2>


### PR DESCRIPTION
After running `pnpm create plasmo`, check it in your browser using `pnpm dev`.
The popup does not spread to the full content.

<img width="69" alt="image" src="https://github.com/PlasmoHQ/examples/assets/32967303/8c4e0a53-6ed5-4545-8c4e-5b896cb89667">

Removing unneeded styles, the popups are now displayed without any problem.

<img width="219" alt="image" src="https://github.com/PlasmoHQ/examples/assets/32967303/cbb0eab2-172c-48cd-88c2-e3efbdd09c34">


