### PR TITLE
Fix mantine example

### DIFF
--- a/with-mantine/popup.tsx
+++ b/with-mantine/popup.tsx
@@ -1,6 +1,7 @@
 import { Anchor, Button, Input, Stack, Text } from "@mantine/core"
 import { useState } from "react"
 
+import "@mantine/core/styles.css"
 import { ThemeProvider } from "~theme"
 
 function IndexPopup() {


### PR DESCRIPTION
It seems like you forgot to import the global styles in the popover of the mantine extension example
I've simply added :
```
import "@mantine/core/styles.css"
``` 
in the list of imports to fix it