### PR TITLE
feat(with-sentry): update with-sentry examples to align with shared environments

### DIFF
--- a/with-sentry/content.ts
+++ b/with-sentry/content.ts
@@ -1,0 +1,22 @@
+import type { PlasmoCSConfig } from "plasmo";
+import { scope as sentryScope, client as sentryClient } from "./sentry";
+
+export const config: PlasmoCSConfig = {
+  matches: ["https://www.plasmo.com/*"],
+};
+
+// do something with scope here
+sentryScope.setTag("content-script", "true");
+
+// all code that could error should be placed here
+try {
+  window.addEventListener("load", () => {
+    console.log(
+      "You may find that having is not so pleasing a thing as wanting. This is not logical, but it is often true.",
+    );
+
+    document.body.style.background = "pink";
+  });
+} catch (err) {
+  sentryClient.captureException(err);
+}

--- a/with-sentry/content.ts
+++ b/with-sentry/content.ts
@@ -1,5 +1,5 @@
 import type { PlasmoCSConfig } from "plasmo";
-import { scope as sentryScope, client as sentryClient } from "./sentry";
+import { scope as sentryScope } from "./sentry";
 
 export const config: PlasmoCSConfig = {
   matches: ["https://www.plasmo.com/*"],
@@ -18,5 +18,5 @@ try {
     document.body.style.background = "pink";
   });
 } catch (err) {
-  sentryClient.captureException(err);
+  sentryScope.captureException(err);
 }

--- a/with-sentry/package.json
+++ b/with-sentry/package.json
@@ -10,8 +10,8 @@
     "package": "plasmo package"
   },
   "dependencies": {
-    "@sentry/browser": "^8.30.0",
-    "@sentry/react": "^8.30.0",
+    "@sentry/browser": "8.30.0",
+    "@sentry/react": "8.30.0",
     "plasmo": "workspace:*",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/with-sentry/package.json
+++ b/with-sentry/package.json
@@ -10,7 +10,8 @@
     "package": "plasmo package"
   },
   "dependencies": {
-    "@sentry/react": "7.93.0",
+    "@sentry/browser": "^8.30.0",
+    "@sentry/react": "^8.30.0",
     "plasmo": "workspace:*",
     "react": "18.2.0",
     "react-dom": "18.2.0"

--- a/with-sentry/popup.tsx
+++ b/with-sentry/popup.tsx
@@ -3,6 +3,7 @@ import { useState } from "react"
 
 const Sentry = _Sentry
 
+// Sentry can be initialized here because this is a tab/popup and is not a shared environment
 Sentry.init({
   dsn: process.env.PLASMO_PUBLIC_SENTRY_DSN
 })

--- a/with-sentry/popup.tsx
+++ b/with-sentry/popup.tsx
@@ -4,6 +4,8 @@ import { useState } from "react"
 const Sentry = _Sentry
 
 // Sentry can be initialized here because this is a tab/popup and is not a shared environment
+// NOTE: Please be wary of this as it will include code that lazy loads sentry code. This could
+// result in the stores rejecting your submission.
 Sentry.init({
   dsn: process.env.PLASMO_PUBLIC_SENTRY_DSN
 })

--- a/with-sentry/sentry.ts
+++ b/with-sentry/sentry.ts
@@ -9,10 +9,10 @@ import {
   Scope
 } from "@sentry/browser";
 
+const excludedIntegrations = new Set(["BrowserApiErrors", "Breadcrumbs", "GlobalHandlers"]);
+
 const integrations = getDefaultIntegrations({}).filter((defaultIntegration) => {
-  return !["BrowserApiErrors", "Breadcrumbs", "GlobalHandlers"].includes(
-    defaultIntegration.name
-  );
+  return !excludedIntegrations.has(defaultIntegration.name);
 });
 
 const sentryClient = new BrowserClient({

--- a/with-sentry/sentry.ts
+++ b/with-sentry/sentry.ts
@@ -1,0 +1,31 @@
+// Context: https://docs.sentry.io/platforms/javascript/best-practices/shared-environments/
+// This really only applies to content scripts that are executed, but we'll set it up for the whole extension here.
+
+import {
+  BrowserClient,
+  defaultStackParser,
+  getDefaultIntegrations,
+  makeFetchTransport,
+  Scope
+} from "@sentry/browser";
+
+const integrations = getDefaultIntegrations({}).filter((defaultIntegration) => {
+  return !["BrowserApiErrors", "Breadcrumbs", "GlobalHandlers"].includes(
+    defaultIntegration.name
+  );
+});
+
+const sentryClient = new BrowserClient({
+  dsn: process.env.PLASMO_PUBLIC_SENTRY_DSN,
+  stackParser: defaultStackParser,
+  integrations,
+  transport: makeFetchTransport
+});
+
+const sentryScope = new Scope();
+sentryScope.setClient(sentryClient);
+
+sentryClient.init(); // initializing has to be done after setting the client on the scope
+
+export const scope = sentryScope;
+export const client = sentryClient;

--- a/with-sentry/sentry.ts
+++ b/with-sentry/sentry.ts
@@ -28,4 +28,3 @@ sentryScope.setClient(sentryClient);
 sentryClient.init(); // initializing has to be done after setting the client on the scope
 
 export const scope = sentryScope;
-export const client = sentryClient;


### PR DESCRIPTION
I went through a lot of variations when upgrading/using Sentry in extensions.

While Sentry does provide [guidance](https://docs.sentry.io/platforms/javascript/best-practices/shared-environments/) when it comes to shared environments, recommending v8, this guidance really only applies to code executed in the content scripts. This is because content scripts are the only thing executed in the same window as the website currently in the browser.

But, what I found out the hard way is that even using Sentry's default way of initialising in the popup script can cause issues, specifically, rejections from the stores.

>**Violation:** Including remotely-hosted code in a Manifest V3 item.

With this code snippet being the one in question.
```
Code snippet: popup.cc3817b7.js: " let u = function(e) { let t = (0, o.getClient)(), r = t && t.getOptions(), n = r && r.cdnBaseUrl || "https://browser.sentry-cdn.com/"; return new URL(`/${(0,o.SDK_VERSION)}/${e}.min.js`, n).toString() }(r), c = (0, s.WINDOW).document.createElement("script"); c.src = u, c.crossOrigin = "anonymous", c.referrerPolicy = "origin", t && c.setAttribute("nonce", t); let p = new Promise((e, t) => { c.addEventListener("load", () => e()), c.addEventListener("error", t) }), d = s.WINDOW.document.currentScript,"
```

After a deep-dive, this code is included when using the `Sentry.init` function. This is because of how the import works (e.g. `import * as Sentry from '@sentry/browser` [or from the react version]), as it actually imports all things, which includes the [lazy loading integration](https://github.com/getsentry/sentry-javascript/blob/master/packages/browser/src/utils/lazyLoadIntegration.ts#L98) [this integration isn't needed when you're bundling code, but hey ho).

I've modified the example to show how to set up Sentry for usage in a content script, which shouldn't have this problem, but I've left the popup initialisation as standard with a comment. Open for discussion!