### PR TITLE
feat: prevent tailwindcss style leakages into CSUI

### DIFF
--- a/with-tailwindcss/src/content.tsx
+++ b/with-tailwindcss/src/content.tsx
@@ -4,13 +4,37 @@ import type { PlasmoCSConfig } from "plasmo"
 import { CountButton } from "~features/count-button"
 
 export const config: PlasmoCSConfig = {
-  matches: ["https://www.plasmo.com/*"]
+  matches: ["<all_urls>"]
 }
 
-export const getStyle = () => {
-  const style = document.createElement("style")
-  style.textContent = cssText
-  return style
+/**
+ * Generates a style element with adjusted CSS to work correctly within a Shadow DOM.
+ *
+ * Tailwind CSS relies on `rem` units, which are based on the root font size (typically defined on the <html>
+ * or <body> element). However, in a Shadow DOM (as used by Plasmo), there is no native root element, so the
+ * rem values would reference the actual page's root font size—often leading to sizing inconsistencies.
+ *
+ * To address this, we:
+ * 1. Replace the `:root` selector with `:host(plasmo-csui)` to properly scope the styles within the Shadow DOM.
+ * 2. Convert all `rem` units to pixel values using a fixed base font size, ensuring consistent styling
+ *    regardless of the host page's font size.
+ */
+export const getStyle = (): HTMLStyleElement => {
+  const baseFontSize = 16
+
+  let updatedCssText = cssText.replaceAll(":root", ":host(plasmo-csui)")
+  const remRegex = /([\d.]+)rem/g
+  updatedCssText = updatedCssText.replace(remRegex, (match, remValue) => {
+    const pixelsValue = parseFloat(remValue) * baseFontSize
+
+    return `${pixelsValue}px`
+  })
+
+  const styleElement = document.createElement("style")
+
+  styleElement.textContent = updatedCssText
+
+  return styleElement
 }
 
 const PlasmoOverlay = () => {

--- a/with-tailwindcss/src/style.css
+++ b/with-tailwindcss/src/style.css
@@ -3,3 +3,8 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+#plasmo-shadow-container {
+  all: initial;
+  box-sizing: border-box;
+}


### PR DESCRIPTION
Related to [discussion ](https://github.com/PlasmoHQ/plasmo/discussions/660)

This fix will prevent size inconsistencies between different host pages, preventing style leaks.

Example before:
![image](https://github.com/user-attachments/assets/69ac2b59-fc0e-456b-b9e9-1ba270bef581)


Example after the change:
![image](https://github.com/user-attachments/assets/b22f0f94-dd59-4d72-a189-acd1e1312c69)


